### PR TITLE
fix: infinite loop in inject

### DIFF
--- a/src/ocLazyLoad.core.js
+++ b/src/ocLazyLoad.core.js
@@ -595,7 +595,7 @@
                         if(angular.isArray(moduleName)) {
                             var promisesList = [];
                             angular.forEach(moduleName, module => {
-                                promisesList.push(self.inject(moduleName, localParams, real));
+                                promisesList.push(self.inject(module, localParams, real));
                             });
                             return $q.all(promisesList);
                         } else {


### PR DESCRIPTION
I'm using ocLazyLoad with webpack and ran into an overflowing call stack when calling `$ocLazyLoad.inject()` manually. Looking at the source, it seems that if you give inject an array it will never stop recursing. By making the change in this PR i was able to fix the issue.

Code snippet of my implementation for reference:

``` js
require.ensure([], function(require) {

  // Require our modules
  // This replaces the `import` statements from above
  let something = require('./about.something'); // an angular module
  let component = require('./about.component'); // Just a directive factory function

  // Inject all dependencies into our module
  // This replaces adding them to the original angular.module dependency array
  $ocLazyLoad.inject([
    something.name // get the string to play nicely with $ocLazyLoad
  ])

  // Register the component so the template recognizes it
  .then(() => $compileProvider.directive('about', component))

  // Continue the state transition
  .then(deferred.resolve);

}, 'about'); // Name our bundle so it shows up pretty in the network tab
```
